### PR TITLE
Fix typographical error(s)

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -79,7 +79,7 @@ You are also free to play around with several robustness modes (RM) and spectrum
 occupancies (SO, signal bandwidth) ranging from 4.5 to 20 kHz. The corresponding
 bit rates vary from below 5 kbps to about 55 kbps. Among other parameters, the
 station label and a text message can also be set by simply adapting the 
-correspondant blocks.
+correspondent blocks.
 
 
 4 (CURRENT) CONSTRAINTS


### PR DESCRIPTION
@fewu, I've corrected a typographical error in the documentation of the [gnuradio_drm](https://github.com/fewu/gnuradio_drm) project. Specifically, I've changed correspondant to correspondent. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.
